### PR TITLE
Feature/template improvs

### DIFF
--- a/.templates/index/index.html
+++ b/.templates/index/index.html
@@ -23,6 +23,43 @@
 	</script>
 
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
+	<style>
+		body {
+			margin: 0;
+			padding: 6.4em 3.2em 3.2em 3.2em;
+			overflow-x: hidden;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+			/*
+				Leaving this out because it was intended to provide a border for actual
+				test files -- this is an index for them and not a test itself.
+			*/
+			/*box-shadow:
+				inset #ccf2fb 0 4.8em 0 0,
+				inset #ccf2fb 0 0 0 1.6em;*/
+		}
+
+		body::before {
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+			background: repeating-linear-gradient(
+				-45deg,
+				#222,
+				#222 10px,
+				#333 10px,
+				#333 20px
+			);
+			padding: 0.8em 3.2em 0.8em 1.6em;
+			content: "🏠 Index of test files";
+			font-family: 'Lucida Sans Typewriter', 'Lucida Console', Monaco, 'Bitstream Vera Sans Mono', monospace;
+			color: white;
+		}
+
+		li {
+			margin-bottom: 0.5em;
+		}
+	</style>
 
 	<!--[if lt IE 9]>
 		<script>
@@ -40,7 +77,7 @@
 		<p role="alert">This website needs JavaScript to work properly.</p>
 	</noscript>
 
-	<h1>All UI-Kit modules</h1>
+	<h1>All UI-Kit module tests</h1>
 
 	<main>
 		<ul>

--- a/.templates/new-module/tests/site/index.html
+++ b/.templates/new-module/tests/site/index.html
@@ -41,6 +41,8 @@
 		<p role="alert">This website needs JavaScript to work properly.</p>
 	</noscript>
 
+	<a href="/">&larr; back to the module index</a>
+
 	<h1>Test: [-replace-name-]</h1>
 
 	code here

--- a/packages/body/tests/site/index.html
+++ b/packages/body/tests/site/index.html
@@ -16,7 +16,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
 
-	<title>Test: body module</title>
+	<title>Test: body</title>
 
 	<script type="text/javascript">
 		var $html=document.documentElement;if($html.classList)$html.classList.remove("no-js"),$html.classList.add("js");else{var className="no-js";$html.className=$html.className.replace(new RegExp("(^|\\b)"+className.split(" ").join("|")+"(\\b|$)","gi")," "),$html.className+=" js"}
@@ -41,6 +41,8 @@
 	<noscript>
 		<p role="alert">This website needs JavaScript to work properly.</p>
 	</noscript>
+
+	<a href="/">&larr; back to the module index</a>
 
 	<h1>Test: body module</h1>
 

--- a/packages/breadcrumbs/tests/site/index.html
+++ b/packages/breadcrumbs/tests/site/index.html
@@ -41,6 +41,8 @@
 		<p role="alert">This website needs JavaScript to work properly.</p>
 	</noscript>
 
+	<a href="/">&larr; back to the module index</a>
+
 	<h1>Test: breadcrumbs</h1>
 
 	<h2>breadcrumbs</h2>

--- a/packages/core/tests/site/index.html
+++ b/packages/core/tests/site/index.html
@@ -41,7 +41,9 @@
 		<p role="alert">This website needs JavaScript to work properly.</p>
 	</noscript>
 
-	<h1>Test: @gov.au/core</h1>
+	<a href="/">&larr; back to the module index</a>
+
+	<h1>Test: core</h1>
 
 	<h2>breakpoints</h2>
 

--- a/packages/footer/src/sass/_module.scss
+++ b/packages/footer/src/sass/_module.scss
@@ -34,6 +34,12 @@
  */
 .uikit-footer__navigation {
 
+	.uikit-linklists {
+		> li {
+			margin-left: 0;
+		}
+	}
+
 	+ .uikit-footer__end {
 		padding-top: uikit-space( 1 );
 		border-top: $uikit-borderize;

--- a/packages/footer/tests/site/index.html
+++ b/packages/footer/tests/site/index.html
@@ -41,6 +41,8 @@
 		<p role="alert">This website needs JavaScript to work properly.</p>
 	</noscript>
 
+	<a href="/">&larr; back to the module index</a>
+
 	<h1>Test: footer</h1>
 
 	<h2>footer</h2>

--- a/packages/grid-12/tests/site/index.html
+++ b/packages/grid-12/tests/site/index.html
@@ -41,6 +41,8 @@
 		<p role="alert">This website needs JavaScript to work properly.</p>
 	</noscript>
 
+	<a href="/">&larr; back to the module index</a>
+
 	<h1>Test: grid-12</h1>
 
 	<main class="uikit-grid">

--- a/packages/headings/tests/site/index.html
+++ b/packages/headings/tests/site/index.html
@@ -41,6 +41,8 @@
 		<p role="alert">This website needs JavaScript to work properly.</p>
 	</noscript>
 
+	<a href="/">&larr; back to the module index</a>
+
 	<h1>Test: headings</h1>
 
 	<div class="row">

--- a/packages/link-lists/tests/site/index.html
+++ b/packages/link-lists/tests/site/index.html
@@ -41,6 +41,8 @@
 		<p role="alert">This website needs JavaScript to work properly.</p>
 	</noscript>
 
+	<a href="/">&larr; back to the module index</a>
+
 	<h1>Test: link-lists</h1>
 
 	<h2>Link list</h2>

--- a/packages/responsive-embeds/tests/site/index.html
+++ b/packages/responsive-embeds/tests/site/index.html
@@ -41,6 +41,8 @@
 		<p role="alert">This website needs JavaScript to work properly.</p>
 	</noscript>
 
+	<a href="/">&larr; back to the module index</a>
+
 	<h1>Test: responsive-embeds</h1>
 
 	<h2>responsive images</h2>

--- a/packages/skip-links/tests/site/index.html
+++ b/packages/skip-links/tests/site/index.html
@@ -47,6 +47,8 @@
 		<p role="alert">This website needs JavaScript to work properly.</p>
 	</noscript>
 
+	<a href="/">&larr; back to the module index</a>
+
 	<h1>Test: skip-links</h1>
 
 	<p>This test file is unique in that the feature being tested is placed outside the <code>body</code> tag and is visually hidden by default.</p>


### PR DESCRIPTION
Makes the following improvements:

- adds styling to the module test file index listing
- adds a “← back to the module index” link for each test file, and the test file scaffolding template
- sets `margin-left:0` for linklists occuring in the nav section of the footer
- makes existing module test file `h1` uniform