### PR TITLE
Fixes markup bug in skip-links.

### DIFF
--- a/packages/skip-links/tests/site/index.html
+++ b/packages/skip-links/tests/site/index.html
@@ -37,12 +37,12 @@
 	<![endif]-->
 </head>
 
-<nav class="uikit-skip-to">
-	<a href="#content">Skip to main content</a>
-	<a href="#nav">Skip to main navigation</a>
-</nav>
+<body class="uikit-body">
+	<nav class="uikit-skip-to">
+		<a href="#content">Skip to main content</a>
+		<a href="#nav">Skip to main navigation</a>
+	</nav>
 
-<body>
 	<noscript>
 		<p role="alert">This website needs JavaScript to work properly.</p>
 	</noscript>

--- a/packages/skip-links/tests/site/test.scss
+++ b/packages/skip-links/tests/site/test.scss
@@ -2,6 +2,7 @@
 @import '../../../core/lib/sass/_module.scss';
 
 //testing includes
+@import '../../../body/lib/sass/_module.scss';
 
 //this module
 @import '_module.scss';


### PR DESCRIPTION
Fixes the placement of the skip-links — they need to sit inside the `body`.