### PR TITLE
Bugfix/tags leading

### DIFF
--- a/packages/tags/src/sass/_module.scss
+++ b/packages/tags/src/sass/_module.scss
@@ -23,7 +23,7 @@
 	color: $uikit-colour-Text;
 	line-height: $uikit-leading;
 	margin-bottom: uikit-space( 0.25 );
-	vertical-align: middle;
+	// vertical-align: middle;
 
 	.uikit-body & {
 		margin-bottom: uikit-space( 0.25 );
@@ -31,8 +31,12 @@
 	}
 
 	> dt {
-		display: inline;
-		vertical-align: middle;
+		display: inline-block;
+		// vertical-align: middle;
+
+		.uikit-body & {
+			margin-bottom: uikit-space( 0.25 );
+		}
 	}
 }
 
@@ -40,21 +44,21 @@
 	border: 1px solid $uikit-colour-Beta-50;
 	border-radius: $uikit-border-radius;
 	display: inline-block;
-	margin: 0 0.4em uikit-space( 0.25 ) 0;
+	margin: 0 uikit-space( 0.25 ) uikit-space( 0.25 ) 0;
 	padding: 0 0.4em;
-	vertical-align: middle;
+	// vertical-align: middle;
 
 	.uikit-body & {
-		padding-left: 0.4em;
 		margin-bottom: uikit-space( 0.25 );
+		padding-left: 0.4em;
 	}
 
 	> a {
 		display: inline-block;
-		text-decoration: none;
-		color: $uikit-colour-Text;
 		margin: 0 -0.4em;
 		padding: 0 0.4em;
+		text-decoration: none;
+		color: $uikit-colour-Text;
 
 		&:hover,
 		&:focus {

--- a/packages/tags/src/sass/_module.scss
+++ b/packages/tags/src/sass/_module.scss
@@ -23,7 +23,6 @@
 	color: $uikit-colour-Text;
 	line-height: $uikit-leading;
 	margin-bottom: uikit-space( 0.25 );
-	// vertical-align: middle;
 
 	.uikit-body & {
 		margin-bottom: uikit-space( 0.25 );
@@ -32,7 +31,6 @@
 
 	> dt {
 		display: inline-block;
-		// vertical-align: middle;
 
 		.uikit-body & {
 			margin-bottom: uikit-space( 0.25 );
@@ -46,7 +44,6 @@
 	display: inline-block;
 	margin: 0 uikit-space( 0.25 ) uikit-space( 0.25 ) 0;
 	padding: 0 0.4em;
-	// vertical-align: middle;
 
 	.uikit-body & {
 		margin-bottom: uikit-space( 0.25 );

--- a/packages/tags/tests/site/index.html
+++ b/packages/tags/tests/site/index.html
@@ -54,6 +54,9 @@
 		<dd class="uikit-tags__item"><a href="#">baz</a></dd>
 		<dd class="uikit-tags__item"><a href="#">bloop</a></dd>
 		<dd class="uikit-tags__item"><a href="#">blip</a></dd>
+		<dd class="uikit-tags__item"><a href="#">wallop</a></dd>
+		<dd class="uikit-tags__item"><a href="#">doodle</a></dd>
+		<dd class="uikit-tags__item"><a href="#">pear icecream</a></dd>
 	</dl>
 
 	<dl class="uikit-tags">
@@ -63,6 +66,9 @@
 		<dd class="uikit-tags__item">baz</dd>
 		<dd class="uikit-tags__item">bloop</dd>
 		<dd class="uikit-tags__item">blip</dd>
+		<dd class="uikit-tags__item">wallop</dd>
+		<dd class="uikit-tags__item">doodle</dd>
+		<dd class="uikit-tags__item">pear icecream</dd>
 	</dl>
 
 	<h2>Tags list using <code>ul</code> and a heading</h2>
@@ -84,6 +90,14 @@
 		<li class="uikit-tags__item">
 			<a href="#">blip</a>
 		</li>
+		<li class="uikit-tags__item">
+			<a href="#">wallop</a>
+		</li>
+		<li class="uikit-tags__item">
+			<a href="#">doodle</a>
+		<li class="uikit-tags__item">
+			<a href="#">pear icecream</a>
+		</li>
 	</ul>
 
 	<span>Tags without links:</span>
@@ -103,6 +117,14 @@
 		<li class="uikit-tags__item">
 			blip
 		</li>
+		<li class="uikit-tags__item">
+			<a href="#">wallop</a>
+		</li>
+		<li class="uikit-tags__item">
+			<a href="#">doodle</a>
+		<li class="uikit-tags__item">
+			<a href="#">pear icecream</a>
+		</li>
 	</ul>
 
 	<div class="uikit-body">
@@ -116,6 +138,9 @@
 			<dd class="uikit-tags__item"><a href="#">baz</a></dd>
 			<dd class="uikit-tags__item"><a href="#">bloop</a></dd>
 			<dd class="uikit-tags__item"><a href="#">blip</a></dd>
+			<dd class="uikit-tags__item"><a href="#">wallop</a></dd>
+			<dd class="uikit-tags__item"><a href="#">doodle</a></dd>
+			<dd class="uikit-tags__item"><a href="#">pear icecream</a></dd>
 		</dl>
 
 		<dl class="uikit-tags">
@@ -125,6 +150,9 @@
 			<dd class="uikit-tags__item">baz</dd>
 			<dd class="uikit-tags__item">bloop</dd>
 			<dd class="uikit-tags__item">blip</dd>
+			<dd class="uikit-tags__item">wallop</dd>
+			<dd class="uikit-tags__item">doodle</dd>
+			<dd class="uikit-tags__item">pear icecream</dd>
 		</dl>
 
 		<h2>Tags list using <code>ul</code> and a heading with body</h2>
@@ -146,6 +174,17 @@
 			<li class="uikit-tags__item">
 				<a href="#">blip</a>
 			</li>
+			<li class="uikit-tags__item">
+				blip
+			</li>
+			<li class="uikit-tags__item">
+				<a href="#">wallop</a>
+			</li>
+			<li class="uikit-tags__item">
+				<a href="#">doodle</a>
+			<li class="uikit-tags__item">
+				<a href="#">pear icecream</a>
+			</li>
 		</ul>
 
 		<span>Tags without links:</span>
@@ -164,6 +203,17 @@
 			</li>
 			<li class="uikit-tags__item">
 				blip
+			</li>
+			<li class="uikit-tags__item">
+				blip
+			</li>
+			<li class="uikit-tags__item">
+				wallop
+			</li>
+			<li class="uikit-tags__item">
+				doodle
+			<li class="uikit-tags__item">
+				pear icecream
 			</li>
 		</ul>
 	</div>

--- a/packages/tags/tests/site/index.html
+++ b/packages/tags/tests/site/index.html
@@ -56,7 +56,7 @@
 		<dd class="uikit-tags__item"><a href="#">blip</a></dd>
 		<dd class="uikit-tags__item"><a href="#">wallop</a></dd>
 		<dd class="uikit-tags__item"><a href="#">doodle</a></dd>
-		<dd class="uikit-tags__item"><a href="#">pear icecream</a></dd>
+		<dd class="uikit-tags__item"><a href="#">pear ice cream</a></dd>
 	</dl>
 
 	<dl class="uikit-tags">
@@ -68,7 +68,7 @@
 		<dd class="uikit-tags__item">blip</dd>
 		<dd class="uikit-tags__item">wallop</dd>
 		<dd class="uikit-tags__item">doodle</dd>
-		<dd class="uikit-tags__item">pear icecream</dd>
+		<dd class="uikit-tags__item">pear ice cream</dd>
 	</dl>
 
 	<h2>Tags list using <code>ul</code> and a heading</h2>
@@ -96,7 +96,7 @@
 		<li class="uikit-tags__item">
 			<a href="#">doodle</a>
 		<li class="uikit-tags__item">
-			<a href="#">pear icecream</a>
+			<a href="#">pear ice cream</a>
 		</li>
 	</ul>
 
@@ -118,12 +118,12 @@
 			blip
 		</li>
 		<li class="uikit-tags__item">
-			<a href="#">wallop</a>
+			wallop
 		</li>
 		<li class="uikit-tags__item">
-			<a href="#">doodle</a>
+			doodle
 		<li class="uikit-tags__item">
-			<a href="#">pear icecream</a>
+			pear ice cream
 		</li>
 	</ul>
 
@@ -140,7 +140,7 @@
 			<dd class="uikit-tags__item"><a href="#">blip</a></dd>
 			<dd class="uikit-tags__item"><a href="#">wallop</a></dd>
 			<dd class="uikit-tags__item"><a href="#">doodle</a></dd>
-			<dd class="uikit-tags__item"><a href="#">pear icecream</a></dd>
+			<dd class="uikit-tags__item"><a href="#">pear ice cream</a></dd>
 		</dl>
 
 		<dl class="uikit-tags">
@@ -152,7 +152,7 @@
 			<dd class="uikit-tags__item">blip</dd>
 			<dd class="uikit-tags__item">wallop</dd>
 			<dd class="uikit-tags__item">doodle</dd>
-			<dd class="uikit-tags__item">pear icecream</dd>
+			<dd class="uikit-tags__item">pear ice cream</dd>
 		</dl>
 
 		<h2>Tags list using <code>ul</code> and a heading with body</h2>
@@ -183,7 +183,7 @@
 			<li class="uikit-tags__item">
 				<a href="#">doodle</a>
 			<li class="uikit-tags__item">
-				<a href="#">pear icecream</a>
+				<a href="#">pear ice cream</a>
 			</li>
 		</ul>
 
@@ -213,7 +213,7 @@
 			<li class="uikit-tags__item">
 				doodle
 			<li class="uikit-tags__item">
-				pear icecream
+				pear ice cream
 			</li>
 		</ul>
 	</div>


### PR DESCRIPTION
Bugfix for `tags` module’s baseline (wasn’t aligned) and the leading between lines.

PR also extends the test HTML to add enough tags to see wrapping easier.

Hovers/focus unchanged.