### PR TITLE
Switches out ' to ’ in core’s uikit-space exception error string.

### DIFF
--- a/packages/core/src/sass/_globals.scss
+++ b/packages/core/src/sass/_globals.scss
@@ -464,7 +464,7 @@ $uikit-border-radius: 3px !default;
  */
 @function uikit-space( $number, $line-height: $uikit-leading ) {
 	@if type-of( $number ) != 'number' {
-		@error "I’m sorry Dave, I can't do that; the uikit-space function only takes a number!";
+		@error "I’m sorry Dave, I can’t do that; the uikit-space function only takes a number!";
 	}
 
 	@if type-of( $number ) == 'number' and not unitless( $number ) {


### PR DESCRIPTION
1-char edit. (:

I noticed this because I ended up reusing this function almost as-is, and noticed when SassDoc went over it that it cut the error string short in the reference doc output.

👋 