### PR TITLE
Added appropriate selection color for dark theme

### DIFF
--- a/packages/body/src/sass/_module.scss
+++ b/packages/body/src/sass/_module.scss
@@ -122,7 +122,8 @@
 	 * Text selection styling
 	 */
 	::selection {
-		background-color: mix( $AU-color-warning, $AU-color-background, 30% );
+		color: $AU-color-background;
+		background-color: rgba( $AU-color-foreground-action, 0.99 );
 	}
 
 	/**
@@ -360,7 +361,8 @@
 		color: $AU-colordark-foreground-text;
 
 		::selection {
-			background-color: mix( $AU-color-warning, $AU-colordark-background, 30% );
+			color: $AU-colordark-background;
+			background-color: rgba( $AU-colordark-foreground-action, 0.99 );
 		}
 
 		a {

--- a/packages/body/src/sass/_module.scss
+++ b/packages/body/src/sass/_module.scss
@@ -359,6 +359,10 @@
 		background: $AU-colordark-background;
 		color: $AU-colordark-foreground-text;
 
+		::selection {
+			background-color: mix( $AU-color-warning, $AU-colordark-background, 30% );
+		}
+
 		a {
 			color: $AU-colordark-foreground-action;
 

--- a/packages/body/src/sass/_module.scss
+++ b/packages/body/src/sass/_module.scss
@@ -124,6 +124,7 @@
 	::selection {
 		color: $AU-color-background;
 		background-color: rgba( $AU-color-foreground-action, 0.99 );
+		// Why RGBA 0.99? https://stackoverflow.com/a/7224621
 	}
 
 	/**
@@ -363,6 +364,7 @@
 		::selection {
 			color: $AU-colordark-background;
 			background-color: rgba( $AU-colordark-foreground-action, 0.99 );
+			// Why RGBA 0.99? https://stackoverflow.com/a/7224621
 		}
 
 		a {

--- a/packages/core/src/sass/_globals.scss
+++ b/packages/core/src/sass/_globals.scss
@@ -28,7 +28,6 @@
 //   - AU-unit
 //   - AU-font
 //   - AU-font-monospace
-//   - AU-font-monospace
 //   - AU-fontsize-map
 //   - AU-lineheight-map
 //   - AU-maxwidth


### PR DESCRIPTION
The selection color is not a11y right now in the dark theme:

<img width="361" alt="screen shot 2018-02-28 at 10 23 30 pm" src="https://user-images.githubusercontent.com/1266923/36785202-254ca67e-1cd6-11e8-90eb-857aabb1dfcf.png">

I fixed it by mixin it with the right dark theme background color

<img width="312" alt="screen shot 2018-02-28 at 10 23 49 pm" src="https://user-images.githubusercontent.com/1266923/36785215-2f54656c-1cd6-11e8-9fd1-aeb8f30d39d3.png">

Signed-off-by: Dominik Wilkowski <Hi@Dominik-Wilkowski.com>