### PR TITLE
Fix an issue where this.toggleClasses() was not available in the call…

### DIFF
--- a/packages/accordion/src/js/react.js
+++ b/packages/accordion/src/js/react.js
@@ -250,6 +250,8 @@ class AUaccordion extends React.PureComponent {
 	 */
 	accordionOpen( elements, speed ) {
 
+		const ToggleClasses = this.toggleClasses;
+
 		// stop event propagation
 		try {
 			window.event.cancelBubble = true;
@@ -292,7 +294,7 @@ class AUaccordion extends React.PureComponent {
 					endSize: 'auto',
 					speed: speed || 250,
 					callback: function() {
-						this.toggleClasses( element, 'opening' );
+						ToggleClasses( element, 'opening' );
 					},
 				});
 			})( target, speed, element );
@@ -309,6 +311,8 @@ class AUaccordion extends React.PureComponent {
 	 *
 	 */
 	accordionClose( elements, speed ) {
+
+		const ToggleClasses = this.toggleClasses;
 
 		// stop event propagation
 		try {
@@ -338,7 +342,7 @@ class AUaccordion extends React.PureComponent {
 					speed: speed || 250,
 					callback: function() {
 						target.style.display = 'none';
-						this.toggleClasses( target, 'close' );
+						ToggleClasses( target, 'close' );
 					},
 				});
 			})( target, speed );


### PR DESCRIPTION
…back scope for AU.animate.Run() calls in accordionOpen() and accordionClose() functions.