### PR TITLE
Accordion titles in au-body au-body--dark do not get the correct colour chevron

### DIFF
--- a/packages/accordion/CHANGELOG.md
+++ b/packages/accordion/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ## Versions
 
+* [v3.0.3 - au-body--dark now changes accordion title colour](v303)
 * [v3.0.2 - Update dependencies](#v302)
 * [v3.0.1 - React accordion open by default](#v301)
 * [v3.0.0 - React accordion open by default](#v300)
@@ -33,6 +34,11 @@
 
 
 ## Release History
+
+### v3.0.3
+
+- `au-body--dark` now changes accordion title colour
+
 
 ### v3.0.2
 

--- a/packages/accordion/README.md
+++ b/packages/accordion/README.md
@@ -252,6 +252,7 @@ The visual test: https://uikit.service.gov.au/packages/accordion/tests/site/
 
 ## Release History
 
+* v3.0.3 - au-body--dark now changes accordion title colour
 * v3.0.2 - Update dependencies
 * v3.0.1 - Updating documentation
 * v3.0.0 - React accordion open by default

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gov.au/accordion",
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"description": "Allow the user to toggle the visibility of an element",
 	"keywords": [
 		"uikit",

--- a/packages/accordion/src/sass/_module.scss
+++ b/packages/accordion/src/sass/_module.scss
@@ -50,7 +50,6 @@
 	width: 100%;
 	box-sizing: border-box;
 	font-weight: bold;
-	background-color: $AU-color-background-shade;
 	position: relative;
 	cursor: pointer;
 
@@ -109,30 +108,31 @@
 			content: ' ▲ ';
 		}
 	}
+}
 
-	.au-accordion--dark & {
-		color: $AU-colordark-foreground-action;
-		background-color: $AU-colordark-background-shade;
+// Dark title styles
+.au-body.au-body--dark .au-accordion__title,
+.au-accordion.au-accordion--dark .au-accordion__title {
+	color: $AU-colordark-foreground-action;
 
-		&:hover {
-			color: $AU-colordark-foreground-text;
+	&:hover {
+		color: $AU-colordark-foreground-text;
 
-			&:after {
-				background-image: AU-svguri('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">' +
-					'	<path fill="#{ $AU-colordark-foreground-text }" d="M64 0l64 64-16 16-64-64"/>' +
-					'	<path fill="#{ $AU-colordark-foreground-text }" d="M64 0l16 16-64 64L0 64"/>' +
-					'</svg>');
-			}
-		}
-
-		@include AU-focus( 'dark' );
-
-		&:after{
+		&:after {
 			background-image: AU-svguri('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">' +
-				'	<path fill="#{ $AU-colordark-foreground-action }" d="M64 0l64 64-16 16-64-64"/>' +
-				'	<path fill="#{ $AU-colordark-foreground-action }" d="M64 0l16 16-64 64L0 64"/>' +
+				'	<path fill="#{ $AU-colordark-foreground-text }" d="M64 0l64 64-16 16-64-64"/>' +
+				'	<path fill="#{ $AU-colordark-foreground-text }" d="M64 0l16 16-64 64L0 64"/>' +
 				'</svg>');
 		}
+	}
+
+	@include AU-focus( 'dark' );
+
+	&:after{
+		background-image: AU-svguri('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">' +
+			'	<path fill="#{ $AU-colordark-foreground-action }" d="M64 0l64 64-16 16-64-64"/>' +
+			'	<path fill="#{ $AU-colordark-foreground-action }" d="M64 0l16 16-64 64L0 64"/>' +
+			'</svg>');
 	}
 }
 

--- a/packages/accordion/src/sass/_module.scss
+++ b/packages/accordion/src/sass/_module.scss
@@ -128,7 +128,7 @@
 
 	@include AU-focus( 'dark' );
 
-	&:after{
+	&:after {
 		background-image: AU-svguri('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">' +
 			'	<path fill="#{ $AU-colordark-foreground-action }" d="M64 0l64 64-16 16-64-64"/>' +
 			'	<path fill="#{ $AU-colordark-foreground-action }" d="M64 0l16 16-64 64L0 64"/>' +


### PR DESCRIPTION
The accordion is flexible and can be used in many ways. Due to this we want `.au-accordion__title` in a `.au-body.au-body--dark` section to get the correct colour chevron.