### PR TITLE
Add outline offset to default style, for easier overrides

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ## Versions
 
+* [v3.0.1 - Focus outline offset to only apply on the default focus state](#v301)
 * [v3.0.0 - Binary search a11y color, replace node-sass with sass](#v300)
 * [v2.0.3 - Change npm run watch browser-sync location](#v203)
 * [v2.0.2 - Update dependencies](#v202)
@@ -32,6 +33,11 @@
 
 
 ## Release History
+
+### v3.0.1
+
+- Focus outline offset to only apply on the default focus state
+
 
 ### v3.0.0
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -255,6 +255,7 @@ The visual test: https://uikit.service.gov.au/packages/core/tests/site/
 
 ## Release History
 
+* v3.0.1 - Focus outline offset to only apply on the default focus state
 * v3.0.0 - Binary search a11y color, replace node-sass with sass
 * v2.0.3 - Change npm run watch browser-sync location
 * v2.0.2 - Update dependencies

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gov.au/core",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"description": "The core module all UI-Kit modules depend on",
 	"keywords": [
 		"uikit",

--- a/packages/core/src/sass/_globals.scss
+++ b/packages/core/src/sass/_globals.scss
@@ -616,6 +616,9 @@ $dependencies: (
 	}
 	@else {
 		outline: 3px solid $AU-color-foreground-focus;
+
+		// Only add the offset if it's the default style
+		outline-offset: 2px;
 	}
 }
 
@@ -626,7 +629,6 @@ $dependencies: (
 @mixin AU-focus( $theme: 'light' ) {
 	&:focus {
 		@include AU-outline( $theme );
-		outline-offset: 2px;
 	}
 
 	// Remove Modzilla inner HTML dotted line. github.com/necolas/normalize.css/blob/master/normalize.css#L285


### PR DESCRIPTION
I noticed that overridding or changing the outline offset it was necessary to do this in the dark and light  themes. With this PR you only need to change the offset once in the light theme.