### PR TITLE
Added back role=contentinfo in footer

### DIFF
--- a/packages/footer/CHANGELOG.md
+++ b/packages/footer/CHANGELOG.md
@@ -15,7 +15,8 @@
 
 ## Versions
 
-* [v2.1.8 - Remove `role="contentinfo"` attribute by on footer](#v218)
+* [v2.1.9 - Add `role="contentinfo"` attribute on footer](#v219)
+* [v2.1.8 - Remove `role="contentinfo"` attribute on footer](#v218)
 * [v2.1.7 - Added an aria-label attribute to the nav element](#v217)
 * [v2.1.6 - Update dependencies](#v216)
 * [v2.1.5 - Removing web pack dev server, updating dependencies](#v215)
@@ -38,9 +39,14 @@
 
 ## Release History
 
+### v2.1.9
+
+- Add `role="contentinfo"` attribute on footer
+
+
 ### v2.1.8 
 
-- Remove `role="contentinfo"` attribute by on footer
+- Remove `role="contentinfo"` attribute on footer
 
 
 ### v2.1.7

--- a/packages/footer/README.md
+++ b/packages/footer/README.md
@@ -115,6 +115,7 @@ The visual test: https://uikit.service.gov.au/packages/footer/tests/site/
 
 ## Release History
 
+* v2.1.9 - Add `role="contentinfo"` attribute on footer
 * v2.1.8 - Remove `role="contentinfo"` attribute on `<footer>`
 * v2.1.7 - Added an aria-label attribute to the nav element
 * v2.1.6 - Update dependencies

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gov.au/footer",
-	"version": "2.1.8",
+	"version": "2.1.9",
 	"description": "Footers help users who reach the bottom of a page without finding what they want.",
 	"keywords": [
 		"uikit",

--- a/packages/footer/src/js/react.js
+++ b/packages/footer/src/js/react.js
@@ -76,6 +76,7 @@ const AUfooter = ({ dark, alt, children, className = '', ...attributeOptions }) 
 	<footer
 		className={ `au-footer ${ className }${ dark ? ' au-footer--dark' : '' }${ alt ? ' au-footer--alt' : '' } `}
 		{ ...attributeOptions }
+		role="contentinfo"
 	>
 		{ children }
 	</footer>

--- a/packages/footer/tests/site/index.html
+++ b/packages/footer/tests/site/index.html
@@ -46,7 +46,7 @@
 
 	<h2>footer</h2>
 
-	<footer class="au-footer">
+	<footer class="au-footer" role="contentinfo">
 		<nav class="au-footer__navigation" aria-label="footer navigation">
 			<p>au-footer__navigation</p>
 		</nav>
@@ -58,7 +58,7 @@
 
 	<h2>footer <code>--alt</code></h2>
 
-	<footer class="au-footer au-footer--alt">
+	<footer class="au-footer au-footer--alt" role="contentinfo">
 		<nav class="au-footer__navigation" aria-label="footer navigation">
 			<p>au-footer__navigation</p>
 		</nav>
@@ -70,7 +70,7 @@
 
 	<h2>footer <code>--dark</code></h2>
 
-	<footer class="au-footer au-footer--dark">
+	<footer class="au-footer au-footer--dark" role="contentinfo">
 		<nav class="au-footer__navigation" aria-label="footer navigation">
 			<p>au-footer__navigation</p>
 		</nav>
@@ -82,7 +82,7 @@
 
 	<h2>footer <code>--alt</code> <code>--dark</code></h2>
 
-	<footer class="au-footer au-footer--alt au-footer--dark">
+	<footer class="au-footer au-footer--alt au-footer--dark" role="contentinfo">
 		<nav class="au-footer__navigation" aria-label="footer navigation">
 			<p>au-footer__navigation</p>
 		</nav>
@@ -96,7 +96,7 @@
 	<h2>footer with paragraph test and body</h2>
 
 	<div class="au-body">
-		<footer class="au-footer">
+		<footer class="au-footer" role="contentinfo">
 			<nav class="au-footer__navigation" aria-label="footer navigation">
 				<p>au-footer__navigation</p>
 				<p>au-footer__navigation</p>
@@ -113,7 +113,7 @@
 	<hr>
 	<h2>footer navigation only</h2>
 
-	<footer class="au-footer">
+	<footer class="au-footer" role="contentinfo">
 		<nav class="au-footer__navigation" aria-label="footer navigation">
 			<p>au-footer__navigation</p>
 		</nav>
@@ -122,7 +122,7 @@
 	<hr>
 	<h2>footer end only</h2>
 
-	<footer class="au-footer">
+	<footer class="au-footer" role="contentinfo">
 		<section class="au-footer__end">
 			<p>au-footer__end</p>
 		</section>
@@ -132,7 +132,7 @@
 	<h2>footer with grid, link-list, responsive-embeds and headings</h2>
 
 	<div class="au-grid au-body">
-		<footer class="au-footer">
+		<footer class="au-footer" role="contentinfo">
 			<div class="container">
 				<nav class="au-footer__navigation row" aria-label="footer navigation">
 					<div class="col-md-3 col-sm-6">
@@ -186,7 +186,7 @@
 	</div>
 
 	<div class="au-grid au-body au-body--dark">
-		<footer class="au-footer au-footer--dark">
+		<footer class="au-footer au-footer--dark" role="contentinfo">
 			<div class="container">
 				<nav class="au-footer__navigation row" aria-label="footer navigation">
 					<div class="col-md-3 col-sm-6">


### PR DESCRIPTION
The `role="contentinfo"` is added on footer element to support for older browsers and screen readers that do not expose the `footer` element as a landmark.

See below for justification

https://accessibility.blog.gov.uk/2016/05/27/using-navigation-landmarks/

https://fae.disability.illinois.edu/rulesets/ROLE_9/

http://www.a11ymatters.com/article/intro-html5-sectioning-elements/

https://a11yproject.com/posts/aria-landmark-roles/


